### PR TITLE
apply pretranslation on vrml mesh to avoid complex matrix decomposition

### DIFF
--- a/simtrans/collada.py
+++ b/simtrans/collada.py
@@ -144,6 +144,7 @@ class ColladaReader(object):
                     m.children.append(cc)
         elif type(d) == collada.scene.GeometryNode:
             m = model.MeshTransformData()
+            m.matrix = numpy.identity(4)
             materialmap = {}
             for mm in d.materials:
                 materialmap[mm.symbol] = self._materials[mm.target.id]
@@ -173,6 +174,8 @@ class ColladaReader(object):
                 except KeyError:
                     sm.material = model.MaterialModel()
                 m.children.append(sm)
+        else:
+            print "unsupported collada node type: " + type(d).__name__
         return m
 
 

--- a/simtrans/model.py
+++ b/simtrans/model.py
@@ -241,6 +241,26 @@ class MeshTransformData(TransformationModel):
         center = minv + half
         return center[0:3]
 
+    def pretranslate(self, trans=None):
+        '''
+        Apply translation to vertex and normals to make translation matrix diagonal
+        '''
+        if trans is None:
+            trans = numpy.identity(4)
+        trans2 = numpy.dot(trans, self.getmatrix())
+        for c in self.children:
+            if type(c) == MeshTransformData:
+                c.pretranslate(trans2)
+            elif type(c) == MeshData:
+                c.vertex = c.vertex.copy()
+                for i in range(0, c.vertex.shape[0]):
+                    c.vertex[i] = numpy.dot(trans2[:3,:3], c.vertex[i]) + trans2[:3,3]
+                if c.normal is not None:
+                    c.normal = c.normal.copy()
+                    for i in range(0, c.normal.shape[0]):
+                        c.normal[i] = numpy.dot(trans2[:3,:3], c.normal[i])
+        self.matrix = numpy.identity(4)
+
 
 class MeshData(object):
     """

--- a/simtrans/template/vrml-mesh.wrl
+++ b/simtrans/template/vrml-mesh.wrl
@@ -119,6 +119,6 @@ Shape {
     {%- endif %}
   }
 }
-  {%- endif %}
-  {%- endif %}
-  {%- endfor %}
+{%- endif %}
+{%- endif %}
+{%- endfor %}

--- a/simtrans/vrml.py
+++ b/simtrans/vrml.py
@@ -403,6 +403,7 @@ class VRMLWriter(object):
         for l in mdata.links:
             for v in l.visuals:
                 if v.shapeType == model.ShapeModel.SP_MESH:
+                    v.data.pretranslate()
                     m = {}
                     m['children'] = [v.data]
                     with open(os.path.join(dirname, mdata.name + "-" + v.name + ".wrl"), 'w') as ofile:


### PR DESCRIPTION
複雑なmatrix decompositionが失敗する対策として事前に頂点座標を変換しておく方式を実装しました。